### PR TITLE
Prepare for stackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,9 @@
 ## 0.1.0.0 -- 2019-09-22
 
 * First version. Released on an unsuspecting world.
+
+## 0.1.1.0 -- 2020-04-28
+
+Added support for GHC 8.8.3, bumped upper bound for base to 4.13.0.0, changed
+`build-tools` for `build-tool-depends` in cabal file. All this as work required
+to add package to stackage.

--- a/dialogflow-fulfillment.cabal
+++ b/dialogflow-fulfillment.cabal
@@ -1,7 +1,8 @@
 cabal-version:       2.4
 name:                dialogflow-fulfillment
-version:             0.1.0.0
+version:             0.1.1.0
 tested-with:         GHC==8.6.4
+                     GHC==8.8.3
 category:            API
 synopsis:            A Dialogflow Fulfillment library for Haskell.
 description:
@@ -41,7 +42,7 @@ library
 
   build-depends:
       aeson >= 1.4.2 && < 1.5
-    , base ^>=4.12.0.0
+    , base ^>=4.13.0.0
     , bytestring >= 0.10.8 && < 0.11
     , containers >= 0.6.0 && < 0.7
     , text >= 1.2.3 && < 1.3
@@ -55,7 +56,7 @@ library
 test-suite dialogflow-fulfillment-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
-  build-tools: hspec-discover
+  build-tool-depends: hspec-discover:hspec-discover
   other-modules:
       TestUtil
       Dialogflow.V2.Fulfillment.MessageSpec


### PR DESCRIPTION
- Support for GHC 8.8.3
- Fix `build-tools` deprecation
- Bump base version upper bound to `4.13.0.0`