### PR TITLE
Update base upper bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@ to add package to stackage.
 ## 0.1.1.1 -- 2020-04-30
 
 Fix `base` bounds for GHC 8.6.* to restore hackage build.
+
+## 0.1.1.2 -- 2020-05-22
+
+Update `base` bounds as required by stackage in preparation for GHC 8.10.

--- a/dialogflow-fulfillment.cabal
+++ b/dialogflow-fulfillment.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                dialogflow-fulfillment
-version:             0.1.1.1
+version:             0.1.1.2
 tested-with:         GHC==8.6.4
                      GHC==8.8.3
 category:            API
@@ -42,7 +42,7 @@ library
 
   build-depends:
       aeson >= 1.4.2 && < 1.5
-    , base >=4.12.0.0 && < 4.14.0.0
+    , base >=4.12.0.0 && < 4.15.0.0
     , bytestring >= 0.10.8 && < 0.11
     , containers >= 0.6.0 && < 0.7
     , text >= 1.2.3 && < 1.3


### PR DESCRIPTION
As required by Stackage to support GHC 8.10 commercialhaskell/stackage#5365.